### PR TITLE
feat: multiple bouncers

### DIFF
--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1,11 +1,8 @@
 def test_override(guest_list, vault, guest):
     assert not vault.authorized(guest, 0)
-    tx = guest_list.set_guest(guest, True)
+    tx = guest_list.invite_guest(guest)
     assert 'GuestInvited' in tx.events
     assert vault.authorized(guest, 0)
-    tx = guest_list.set_guest(guest, False)
-    assert 'GuestRemoved' in tx.events
-    assert not vault.authorized(guest, 0)
 
 
 def test_yfi(guest_list, vault, guest, yfi):


### PR DESCRIPTION
Changes:
- change single `bouncer` role to multiple `bouncers`
- add `governance` role
- add `treasury` role

Auth:
- `bouncers` can `invite_guest`, `add_bouncer`
- `governance` can `set_bribe_cost`, `add_bouncer`, `remove_bouncer`, `set_governance`, `set_treasury`
- `treasury` is just the bribe destination, it can't change anything